### PR TITLE
feat: add download item to note context menu

### DIFF
--- a/components.jsx
+++ b/components.jsx
@@ -1598,6 +1598,7 @@ function StickyNote({note, T, tweaks, folder, refCb, selected, selectedIds, setS
             {label: (selected && selectedIds && selectedIds.size > 1)
               ? 'Copy ' + selectedIds.size + ' notes'
               : 'Copy', onClick: () => onCopy && onCopy()},
+            {label:'Download', onClick:()=>downloadNoteAsMarkdown(note)},
             {divider:true},
             {label:'Edit title', onClick:()=>setEditingTitle(true)},
             {label:'Edit body', onClick:()=>setEditing(true)},

--- a/main.js
+++ b/main.js
@@ -207,6 +207,25 @@ ipcMain.handle('notes:export', async (_e, data) => {
   }
 });
 
+// Context-menu "Download": save one note's content as a markdown file. The
+// renderer supplies both the suggested filename (derived from the note's
+// title / first line, already sanitized) and the full file content.
+ipcMain.handle('notes:export-markdown', async (_e, payload) => {
+  const { filename, content } = payload || {};
+  const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
+    title: 'Download note',
+    defaultPath: typeof filename === 'string' && filename ? filename : 'note.md',
+    filters: [{ name: 'Markdown', extensions: ['md'] }],
+  });
+  if (canceled || !filePath) return { ok: false, canceled: true };
+  try {
+    fs.writeFileSync(filePath, typeof content === 'string' ? content : '', 'utf8');
+    return { ok: true, path: filePath };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+});
+
 ipcMain.handle('notes:import', async () => {
   const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
     title: 'Restore backup',

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../sticky-notes/node_modules

--- a/preload.js
+++ b/preload.js
@@ -5,6 +5,9 @@ contextBridge.exposeInMainWorld('stickyAPI', {
   save:       (data) => ipcRenderer.invoke('notes:save', data),
   exportFile: (data) => ipcRenderer.invoke('notes:export', data),
   importFile: () => ipcRenderer.invoke('notes:import'),
+  // Context-menu "Download": save a single note as a markdown file via the
+  // OS save dialog. payload = { filename, content }.
+  exportMarkdown: (payload) => ipcRenderer.invoke('notes:export-markdown', payload),
 
   // Version of the running Electron build, captured at preload time so the
   // renderer can synchronously compare to the latest GitHub release tag.

--- a/tests/download.test.mjs
+++ b/tests/download.test.mjs
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+// utils.jsx is a browser-global script (no module exports). Same loading
+// trick as folders.test.mjs: run it in a vm sandbox with light shims and
+// read the pure helpers back off the shimmed `window`.
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const code = fs.readFileSync(path.join(dir, '..', 'utils.jsx'), 'utf8');
+const sandbox = { React: {}, window: {}, document: {}, navigator: {}, console, Math, JSON, Date };
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+const { noteDownloadFilename, noteToMarkdown } = sandbox.window;
+
+/* ---------------- noteDownloadFilename ---------------- */
+
+test('filename comes from the note title', () => {
+  assert.equal(noteDownloadFilename({ title: 'Groceries', body: 'x' }), 'Groceries.md');
+});
+
+test('filename strips filesystem-hostile characters', () => {
+  assert.equal(
+    noteDownloadFilename({ title: 'a/b\\c:d*e?f"g<h>i|j', body: '' }),
+    'a b c d e f g h i j.md');
+});
+
+test('filename strips control characters', () => {
+  assert.equal(noteDownloadFilename({ title: 'plan\u0000A\tB', body: '' }), 'plan A B.md');
+});
+
+test('filename collapses runs of whitespace and trims', () => {
+  assert.equal(noteDownloadFilename({ title: '  Sprint   42   scope ', body: '' }), 'Sprint 42 scope.md');
+});
+
+test('blank title falls back to the first non-empty body line', () => {
+  assert.equal(
+    noteDownloadFilename({ title: '  ', body: '\n\nRouter reboot\nssh admin@10.0.0.1' }),
+    'Router reboot.md');
+});
+
+test('body-line fallback drops a leading heading marker', () => {
+  assert.equal(noteDownloadFilename({ title: '', body: '## Build flags\nstuff' }), 'Build flags.md');
+});
+
+test('body-line fallback drops a leading bullet marker', () => {
+  assert.equal(noteDownloadFilename({ title: '', body: '- Sourdough\n- olive oil' }), 'Sourdough.md');
+});
+
+test('title that sanitizes away to nothing falls back to the body', () => {
+  assert.equal(noteDownloadFilename({ title: '///', body: 'Dinner: friday' }), 'Dinner friday.md');
+});
+
+test('empty note falls back to note.md', () => {
+  assert.equal(noteDownloadFilename({ title: '', body: '' }), 'note.md');
+  assert.equal(noteDownloadFilename({}), 'note.md');
+  assert.equal(noteDownloadFilename(undefined), 'note.md');
+});
+
+test('filename base is capped at 60 characters', () => {
+  const name = noteDownloadFilename({ title: 'x'.repeat(200), body: '' });
+  assert.equal(name, 'x'.repeat(60) + '.md');
+});
+
+test('no trailing dots or spaces survive (Windows-safe)', () => {
+  assert.equal(noteDownloadFilename({ title: 'notes...', body: '' }), 'notes.md');
+  // Truncation at the cap must not leave a trailing space either.
+  const name = noteDownloadFilename({ title: 'y'.repeat(59) + ' zzzz', body: '' });
+  assert.equal(name, 'y'.repeat(59) + '.md');
+});
+
+test('no dotfile names: leading dots are stripped', () => {
+  assert.equal(noteDownloadFilename({ title: '.bashrc notes', body: '' }), 'bashrc notes.md');
+});
+
+/* ---------------- noteToMarkdown ---------------- */
+
+test('title stays out of the file — body only, round-trip safe', () => {
+  assert.equal(
+    noteToMarkdown({ title: 'Standup', body: '**Yday:** fixed dnd bug' }),
+    '**Yday:** fixed dnd bug\n');
+});
+
+test('untitled note exports the body alone', () => {
+  assert.equal(noteToMarkdown({ title: '', body: 'just the body' }), 'just the body\n');
+});
+
+test('empty body exports a single newline', () => {
+  assert.equal(noteToMarkdown({ title: 'Ideas', body: '' }), '\n');
+});
+
+test('trailing whitespace collapses to exactly one final newline', () => {
+  assert.equal(noteToMarkdown({ title: '', body: 'line\n\n\n  ' }), 'line\n');
+});
+
+test('body markdown is preserved verbatim', () => {
+  const body = '## This sprint\n- onboarding polish\n- dnd quick fix';
+  assert.equal(noteToMarkdown({ title: 'Sprint 42', body }), body + '\n');
+});

--- a/utils.jsx
+++ b/utils.jsx
@@ -282,13 +282,60 @@ function firstStrongDir(text = '') {
   return 'ltr';
 }
 /* ---------- Browser-side file helpers (used when window.stickyAPI is absent) ---------- */
-function downloadJSON(filename, obj) {
-  const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+function downloadBlob(filename, blob) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url; a.download = filename;
   document.body.appendChild(a); a.click();
   setTimeout(() => { document.body.removeChild(a); URL.revokeObjectURL(url); }, 0);
+}
+
+function downloadJSON(filename, obj) {
+  downloadBlob(filename, new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' }));
+}
+
+/* ---------- Download a note as markdown (context-menu "Download") ---------- */
+
+// Filesystem-safe .md filename for a note: the title, or (when the title is
+// blank or sanitizes away to nothing) the first non-empty body line with any
+// leading heading/bullet marker dropped, or "note" as the last resort.
+// Pure so it's unit-testable.
+function noteDownloadFilename(note) {
+  const clean = (s) => (s || '')
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, ' ')  // fs-hostile chars (Windows superset)
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 60)
+    .replace(/^\.+/, '')     // no dotfiles
+    .replace(/[. ]+$/, '');  // Windows forbids trailing dots/spaces
+  const firstLine = ((note && note.body) || '')
+    .split('\n').map(l => l.trim()).find(l => l !== '') || '';
+  const base = clean((note && note.title) || '')
+    || clean(firstLine.replace(/^(?:#{1,6}|[-*])\s+/, ''))
+    || 'note';
+  return base + '.md';
+}
+
+// Markdown file content for a note: the body verbatim — note bodies ARE
+// markdown. The title lives in the filename only, so pasting the file's
+// contents into a new note reproduces the body exactly. Always ends in
+// exactly one newline.
+function noteToMarkdown(note) {
+  const body = ((note && note.body) || '').replace(/\s+$/, '');
+  return body + '\n';
+}
+
+// Save a single note as a .md file: native save dialog under Electron (the
+// notes:export-markdown IPC), Blob anchor download in the web demo — same
+// degradation pattern as openWebLink / the JSON backup helpers above.
+function downloadNoteAsMarkdown(note) {
+  const filename = noteDownloadFilename(note);
+  const content  = noteToMarkdown(note);
+  if (window.stickyAPI && window.stickyAPI.exportMarkdown) {
+    window.stickyAPI.exportMarkdown({ filename, content }).catch(err => console.warn('[download]', err));
+  } else {
+    downloadBlob(filename, new Blob([content], { type: 'text/markdown' }));
+  }
 }
 
 function pickJSONFile() {
@@ -536,4 +583,4 @@ function downloadUrlForPlatform(version) {
 const MOBILE_BANNER_DISMISSED_KEY = 'stickies.mobileBannerDismissed';
 const MOBILE_BANNER_MAX_WIDTH = 640;
 
-Object.assign(window, { FOLDER_HUES, MOBILE_BANNER_DISMISSED_KEY, MOBILE_BANNER_MAX_WIDTH, NOTE_COLORS, SEED, STICKY_CLIPBOARD_MARKER, TWEAK_DEFAULTS, canMoveFolder, clipboardTextToNotes, cmpSemver, downloadJSON, downloadUrlForPlatform, editLinkOnPaste, editListOnEnter, editListOnTab, flattenFolderTree, folderPath, folderSubtreeIds, hashRot, mdToHtml, notesToClipboardText, openWebLink, pickJSONFile, sanitizeFolderParents, themeTokens, uid, withA, withDefaults });
+Object.assign(window, { FOLDER_HUES, MOBILE_BANNER_DISMISSED_KEY, MOBILE_BANNER_MAX_WIDTH, NOTE_COLORS, SEED, STICKY_CLIPBOARD_MARKER, TWEAK_DEFAULTS, canMoveFolder, clipboardTextToNotes, cmpSemver, downloadJSON, downloadNoteAsMarkdown, downloadUrlForPlatform, editLinkOnPaste, editListOnEnter, editListOnTab, flattenFolderTree, folderPath, folderSubtreeIds, hashRot, mdToHtml, noteDownloadFilename, noteToMarkdown, notesToClipboardText, openWebLink, pickJSONFile, sanitizeFolderParents, themeTokens, uid, withA, withDefaults });


### PR DESCRIPTION
Adds a **Download** item to the note context menu that saves a single note as a markdown file, per the request and mockups in #28.

- Electron: native save dialog via a new `notes:export-markdown` IPC handler, mirroring the existing backup-export flow
- Web demo: Blob anchor download fallback, same degradation pattern as other Electron-only features
- Filename derives from the note title (fallback: first body line, then `note`), sanitized Windows-safe, capped at 60 chars, `.md` extension
- File content is the note body verbatim with exactly one trailing newline — the title lives in the filename only, so pasting the file's contents into a new note reproduces the body exactly
- 17 new tests (filename sanitization matrix, content contract); suite 106/106 green

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)